### PR TITLE
CI: Fix warnings & deprecation messages in the workflows 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup .NET SDK v7.0.x
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 7.0.x
       - name: Restore tool
@@ -33,11 +33,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
             5.0.x
@@ -51,17 +51,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup .NET SDK v7.0.x
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 7.0.x
       - name: Pack
         run: dotnet pack --configuration=Release
       - name: Upload NuGet package artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nuget-packages
           path: artefacts/*.nupkg
@@ -74,7 +74,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Download NuGet package artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nuget-packages
           path: artefacts

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,6 +72,8 @@ jobs:
     if: ${{ !github.event.repository.fork && startsWith(github.ref, 'refs/tags/v') }}
     needs: SolutionValidator
     runs-on: windows-latest
+    permissions:
+      contents: write
     steps:
       - name: Download NuGet package artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
### What type of PR is this?

CI: Resolve deprecation & warning messages in workflows 
Enable DependaBot for GitHub actions

### What this PR does / why we need it:

Node16 has been out of support since [September 2023](https://github.com/nodejs/Release/#end-of-life-releases). - more info in the [post](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/) 

- Fix CI warnings/deprecations in used action (commit)
- Add required permission to publish github release

### Which issue(s) this PR fixes:

https://github.com/G-Research/gr-oss/issues/686

**__NOTE__**: There are [warnings](https://github.com/gr-oss-devops/SolutionValidator/actions/runs/9032043238) for using `Net5.0` which is not maintained anymore

```
The target framework 'net5.0' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/dotnet-core-support for more information about the support policy.
```

------------

# Testing results

## PASSED 🟢 

**CI**
 - https://github.com/gr-oss-devops/SolutionValidator/actions/runs/9032271721
 **__NOTE__** `Public to Nuget` job failed as tag is not matching release number, this job is not using any external action